### PR TITLE
Use fuzz tests for swipe directions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 index.html
 elm-stuff
 documentation.json
+/tests/elm-stuff
+/tests/elm-package.json
+/tests/.gitignore

--- a/README.md
+++ b/README.md
@@ -15,4 +15,8 @@ Be sure to view in a mobile device emulator like the one found in Chrome Dev Too
 
 ## Run tests
 
-`elm-make tests/Main.elm && open index.html`
+1. Run `npm install -g elm-test` if you haven't already.
+2. `cd` into the project's root directory that has your `elm-package.json`.
+3. Run `elm-test init`. 
+4. Run `elm-test`.
+

--- a/elm-package.json
+++ b/elm-package.json
@@ -5,14 +5,12 @@
     "license": "BSD3",
     "source-directories": [
         "src",
-        "examples",
-        "tests"
+        "examples"
     ],
     "exposed-modules": [
         "TouchEvents"
     ],
     "dependencies": {
-        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,10 +1,6 @@
 port module Main exposing (..)
 
-import TouchEvents as TE
 import Tests
-import Test as ET
-import Expect
-import Fuzz
 import Test.Runner.Node as TRN
 import Json.Encode as JE
 

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,50 +1,17 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest as ET
 import TouchEvents as TE
+import Tests
+import Test as ET
+import Expect
+import Fuzz
+import Test.Runner.Node as TRN
+import Json.Encode as JE
 
 
-main : Program Never
+port emit : ( String, JE.Value ) -> Cmd msg
+
+
+main : TRN.TestProgram
 main =
-    ET.runSuiteHtml touchEventsTests
-
-
-touchEventsTests : ET.Test
-touchEventsTests =
-    ET.suite "Touch Event Test Suite"
-        [ getDirectionXRightTest
-        , getDirectionXLeftTest
-        , getDirectionYUpTest
-        , getDirectionYDownTest
-        , emptyTouchText
-        ]
-
-
-getDirectionXRightTest =
-    ET.test
-        "detects the touch in the Right direction"
-        (ET.assert (TE.getDirectionX 12.12 13.2 == TE.Right))
-
-
-getDirectionXLeftTest =
-    ET.test
-        "detects the touch in the Left direction"
-        (ET.assert (TE.getDirectionX 13.2 12.12 == TE.Left))
-
-
-getDirectionYUpTest =
-    ET.test
-        "detects the touch in the Up direction"
-        (ET.assert (TE.getDirectionY 13.2 12.12 == TE.Up))
-
-
-getDirectionYDownTest =
-    ET.test
-        "detects the touch in the Down direction"
-        (ET.assert (TE.getDirectionY 12.12 13.2 == TE.Down))
-
-
-emptyTouchText =
-    ET.test
-        "returns an empty Touch type"
-        (ET.assert (TE.emptyTouch == { clientX = 0, clientY = 0 }))
+    TRN.run emit Tests.touchEventsTests

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,0 +1,49 @@
+module Tests exposing (..)
+
+import TouchEvents as TE
+import Test as ET
+import Expect
+import Fuzz
+
+
+touchEventsTests : ET.Test
+touchEventsTests =
+    ET.describe "Touch Event Test Suite"
+        [ getXDirectionTest
+        , getYDirectionTest
+        , emptyTouchText
+        ]
+
+
+getXDirectionTest =
+    ET.fuzz2 Fuzz.float Fuzz.float "detects the touch direction on the x-axis"
+        <| \n1 n2 ->
+            case n1 > n2 of
+                True ->
+                    Expect.true "Expected swiping left to return a Left TouchEvent"
+                        (TE.getDirectionX n1 n2 == TE.Left)
+
+                False ->
+                    Expect.true "Expected swiping right to return a Right TouchEvent"
+                        (TE.getDirectionX n1 n2 == TE.Right)
+
+
+getYDirectionTest =
+    ET.fuzz2 Fuzz.float Fuzz.float "detects the touch direction on the y-axis"
+        <| \n1 n2 ->
+            case n1 > n2 of
+                True ->
+                    Expect.true "Expected swiping up to return an Up TouchEvent"
+                        (TE.getDirectionY n1 n2 == TE.Up)
+
+                False ->
+                    Expect.true "Expected swiping down to return a Down TouchEvent"
+                        (TE.getDirectionY n1 n2 == TE.Down)
+
+
+emptyTouchText =
+    ET.test "returns an empty Touch type"
+        <| \() ->
+            (Expect.true "Expected an empty touch to have x and y values of 0"
+                (TE.emptyTouch == { clientX = 0, clientY = 0 })
+            )

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -11,7 +11,7 @@ touchEventsTests =
     ET.describe "Touch Event Test Suite"
         [ getXDirectionTest
         , getYDirectionTest
-        , emptyTouchText
+        , emptyTouchTest
         ]
 
 
@@ -41,7 +41,7 @@ getYDirectionTest =
                         (TE.getDirectionY n1 n2 == TE.Down)
 
 
-emptyTouchText =
+emptyTouchTest =
     ET.test "returns an empty Touch type"
         <| \() ->
             (Expect.true "Expected an empty touch to have x and y values of 0"


### PR DESCRIPTION
Use values generated by [elm-test](http://package.elm-lang.org/packages/elm-community/elm-test/latest)'s float fuzzer instead of hardcoded float values when testing the `getDirection` functions.

Removed elm-test dependency #15 
Tests updated to work with the latest version of elm-test #7 